### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 KCP-Server
 ===========
-##作为kcptun的搬运工，我只是提供了一键安装脚本，至于使用的原理啊、功能啊、bug啊请各位移步到kcptun项目，我真的无能为力。
+## 作为kcptun的搬运工，我只是提供了一键安装脚本，至于使用的原理啊、功能啊、bug啊请各位移步到kcptun项目，我真的无能为力。
 
 
-##感谢[kcptun](https://github.com/xtaci/kcptun)提供这么优秀的软件
+## 感谢[kcptun](https://github.com/xtaci/kcptun)提供这么优秀的软件
 kcptun是kcp协议的一个简单应用，可以用于任意tcp网络程序的传输承载，以提高网络流畅度，降低掉线情况。
 
 脚本是业余爱好，英文属于文盲，写的不好，不要笑话我，欢迎您批评指正。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
